### PR TITLE
Define SCI_NAMESPACE for QScintilla Port

### DIFF
--- a/ports/qscintilla/portfile.cmake
+++ b/ports/qscintilla/portfile.cmake
@@ -17,6 +17,7 @@ set(BUILD_OPTIONS
     "${SOURCE_PATH}/Qt4Qt5/qscintilla.pro"
     CONFIG+=build_all
     CONFIG-=hide_symbols
+    DEFINES += SCI_NAMESPACE
 )
 
 SET(ENV{PATH} "$ENV{PATH};${CURRENT_INSTALLED_DIR}/bin;${CURRENT_INSTALLED_DIR}/debug/bin")
@@ -30,6 +31,7 @@ vcpkg_configure_qmake(
     OPTIONS
         CONFIG+=build_all
         CONFIG-=hide_symbols
+        DEFINES += SCI_NAMESPACE
 )
 
 vcpkg_build_qmake(


### PR DESCRIPTION
This fixes conflicts when using QScintilla statically. Otherwise it's possible that QScintilla will conflict with internal Qt sources.

```
Qt5FontDatabaseSupportd.lib(qwindowsfontdatabase.obj) : error LNK2005: "public: __thiscall FontNames::FontNames(void)" (??0FontNames@@QAE@XZ) already defined in qscintilla2.lib(ViewStyle.obj)
```

It seems both Qt5 and QScintilla have a class named FontNames that results in this linker error when linking to QScintilla statically. This fixes that problem by making the default QScintilla configuration in VCPKG be namespaced.